### PR TITLE
Fix: release workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [master, develop]
+    branches: [main, develop]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -46,6 +46,7 @@ jobs:
         id: release
         uses: cycjimmy/semantic-release-action@v4
         with:
+          semantic_version: 16
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',


### PR DESCRIPTION
## Description

Trying to fix the github release and its versioning

## Changes

- Changed release to run on pushes to main instead of master.
- Added versioning for semantic release to enable correct versioning

## Notes