### PR TITLE
fix: Change docker publish to run on pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,10 +6,7 @@ name: Docker Release
 # documentation.
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: 
-      - completed
+  push:
     branches: ["main", "develop"]
 
 env:
@@ -21,7 +18,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Description
- Change docker publish to run on pushes to main or develop branches, should be okay since pushes should only be allowed after pull request actions (tests) have passed.

## Changes
- Changed semantic release to run on all pushes on main or develop branches.

## Notes